### PR TITLE
fixing rise.Times

### DIFF
--- a/rise/rise.go
+++ b/rise/rise.go
@@ -131,9 +131,11 @@ func Times(p globe.Coord, ΔT, h0, Th0 float64, α3, δ3 []float64) (mRise, mTra
 		α := d3α.InterpolateX(ut)
 		δ := d3δ.InterpolateX(ut)
 		H := th0 - (p.Lon+α)*43200/math.Pi
+		Hrad := H/240*math.Pi/180
 		sδ, cδ := math.Sincos(δ)
-		h := sLat*sδ + cLat*cδ*math.Cos(H)
-		return m + (h-h0)/cδ*cLat*math.Sin(H), nil
+		h := math.Asin(sLat*sδ + cLat*cδ*math.Cos(Hrad))
+		md := (h-h0)*43200/(math.Pi*cδ*cLat*math.Sin(Hrad))
+		return m + md, nil
 	}
 	mRise, err = adjustRS(mRise)
 	if err != nil {

--- a/rise/rise_test.go
+++ b/rise/rise_test.go
@@ -75,7 +75,7 @@ func ExampleTimes() {
 	fmt.Println("transit:", sexa.NewFmtTime(transit))
 	fmt.Println("seting: ", sexa.NewFmtTime(set))
 	// Output:
-	// rising:  12ʰ26ᵐ9ˢ
+	// rising:  12ʰ25ᵐ26ˢ
 	// transit: 19ʰ40ᵐ30ˢ
-	// seting:  2ʰ54ᵐ26ˢ
+	// seting:  2ʰ54ᵐ40ˢ
 }


### PR DESCRIPTION
This fixes the `rise.Times` function for `rise` and `set` results.