### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/v3/elementequinox/elementequinox.go
+++ b/v3/elementequinox/elementequinox.go
@@ -48,7 +48,7 @@ var (
 	_J  = unit.AngleFromDeg(.00651966)
 )
 
-// ReduceB1950ToJ2000 reduces orbital elements of a solar system body from
+// ReduceB1950FK4ToJ2000FK5 reduces orbital elements of a solar system body from
 // equinox B1950 in the FK4 system to equinox J2000 in the FK5 system.
 func ReduceB1950FK4ToJ2000FK5(eFrom, eTo *Elements) *Elements {
 	W := _L + eFrom.Node

--- a/v3/interp/interp.go
+++ b/v3/interp/interp.go
@@ -163,7 +163,7 @@ func (d *Len3) Extremum() (x, y float64, err error) {
 	return x, y, nil
 }
 
-// Len3Zero finds a zero of the quadratic function represented by the table.
+// Zero finds a zero of the quadratic function represented by the table.
 //
 // That is, it returns an x value that yields y=0.
 //
@@ -350,7 +350,7 @@ func (d *Len5) Extremum() (x, y float64, err error) {
 	return x, y, nil
 }
 
-// Len5Zero finds a zero of the quartic function represented by the table.
+// Zero finds a zero of the quartic function represented by the table.
 //
 // That is, it returns an x value that yields y=0.
 //

--- a/v3/iterate/iterate.go
+++ b/v3/iterate/iterate.go
@@ -33,7 +33,7 @@ func DecimalPlaces(better BetterFunc, start float64, places, maxIterations int) 
 	return 0, errors.New("Maximum iterations reached")
 }
 
-// FullPrecison iterates to (nearly) the full precision of a float64.
+// FullPrecision iterates to (nearly) the full precision of a float64.
 //
 // To allow for a little bit of floating point jitter, FullPrecision iterates
 // to 15 significant figures, which is the maximum number of full significant

--- a/v3/precess/precess.go
+++ b/v3/precess/precess.go
@@ -239,7 +239,7 @@ func NewEclipticPrecessor(epochFrom, epochTo float64) *EclipticPrecessor {
 	return p
 }
 
-// EclipticPrecess precesses coordinates eclFrom, leaving result in eclTo.
+// Precess precesses coordinates eclFrom, leaving result in eclTo.
 //
 // The same struct may be used for eclFrom and eclTo.
 // EclTo is returned for convenience.


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?